### PR TITLE
Cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## 1.0.3
 - Changelog created.
+
+## 1.0.4
+- Fixed readme installation guide
+- Added build status for development branch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,5 +3,17 @@ All notable changes to the "tcc-compiler" extension will be documented in this f
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## [Unreleased]
-- Initial release
+## 1.0.0
+### Added
+- TCC: Run
+- TCC: Compile
+- TCC: Set flags...
+
+## 1.0.1
+- Readme updated with command information
+
+## 1.0.2
+- Readme updated with license information
+
+## 1.0.3
+- Changelog created.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 [![Build Status](https://travis-ci.org/LiHRaM/vscode-tcc-compiler.svg?branch=master)](https://travis-ci.org/LiHRaM/vscode-tcc-compiler)
+[![Build Status](https://travis-ci.org/LiHRaM/vscode-tcc-compiler.svg?branch=development)](https://travis-ci.org/LiHRaM/vscode-tcc-compiler)
+
 
 # TCC Compiler README
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ ext install tcc-compiler
 - Compiler: ```Tiny C compiler``` - https://bellard.org/tcc/
 
 ## License
-MIT
+MIT - Extension
+GNU Lesser General Public License (LGPL) - Tiny C Compiler
 
 ## Contact info
 veeravat.jeen@bumail.net <-- Original author

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
+# Build status
+## Master branch
 [![Build Status](https://travis-ci.org/LiHRaM/vscode-tcc-compiler.svg?branch=master)](https://travis-ci.org/LiHRaM/vscode-tcc-compiler)
+## Development
 [![Build Status](https://travis-ci.org/LiHRaM/vscode-tcc-compiler.svg?branch=development)](https://travis-ci.org/LiHRaM/vscode-tcc-compiler)
-
 
 # TCC Compiler README
 
@@ -8,7 +10,7 @@ This extension offers quick and hassle-free C compiling with the TCC compiler.
 
 ## Install 
 ```sh
-ext install tcc-compiler
+ext install vscode-tcc-compiler
 ```
 ## Features
 - Completely independent.

--- a/README.md
+++ b/README.md
@@ -10,17 +10,14 @@ ext install tcc-compiler
 ```
 ## Features
 - Completely independent.
-- Instantly run the program by pressing ```F10```
-- Compile to executable file.
-
-## How To use?
-- Run script  >> ```F10``` <<
-- Compile script   >> ```command: tcc:Compile ``` <<
+- Instantly run the program by using palette command ```TCC: Run```
+- Compile to executable file with palette command ```TCC: Compile```
+- Set custom compilation flags with palette command ```TCC: Set flags...```
 
 ## FYI
-- Only supports Windows.
+- Currently only supports windows, although TCC compiler can be downloaded for Linux and MacOS as well from http://download.savannah.gnu.org/releases/tinycc/
 - Supports: ```C```
-- Compiler: ```Tiny C compiler```
+- Compiler: ```Tiny C compiler``` - https://bellard.org/tcc/
 
 ## License
 MIT

--- a/package.json
+++ b/package.json
@@ -21,19 +21,14 @@
                 "title": "Run",
                 "category": "TCC"
             },
-            {
-                "command": "tcc-compiler.runWithFlags",
-                "title": "Run with flags...",
-                "category": "TCC"
-            },
 						{
 							"command": "tcc-compiler.compile",
 							"title": "Compile",
 							"category": "TCC"
 						},
 						{
-							"command": "tcc-compiler.compileWithFlags",
-							"title": "Compile with flags...",
+							"command": "tcc-compiler.setFlags",
+							"title": "Set flags...",
 							"category": "TCC"
 						}
         ]

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-tcc-compiler",
     "displayName": "TCC Compiler",
     "description": "Extension to simplify use of Tiny C Compiler in VSCode.",
-    "version": "0.0.1",
+    "version": "1.0.0",
     "publisher": "lihram",
     "engines": {
         "vscode": "^1.12.0"
@@ -21,16 +21,16 @@
                 "title": "Run",
                 "category": "TCC"
             },
-						{
-							"command": "tcc-compiler.compile",
-							"title": "Compile",
-							"category": "TCC"
-						},
-						{
-							"command": "tcc-compiler.setFlags",
-							"title": "Set flags...",
-							"category": "TCC"
-						}
+            {
+                "command": "tcc-compiler.compile",
+                "title": "Compile",
+                "category": "TCC"
+            },
+            {
+                "command": "tcc-compiler.setFlags",
+                "title": "Set flags...",
+                "category": "TCC"
+            }
         ]
     },
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-tcc-compiler",
     "displayName": "TCC Compiler",
     "description": "Extension to simplify use of Tiny C Compiler in VSCode.",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "publisher": "lihram",
     "engines": {
         "vscode": "^1.12.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-tcc-compiler",
     "displayName": "TCC Compiler",
     "description": "Extension to simplify use of Tiny C Compiler in VSCode.",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "publisher": "lihram",
     "engines": {
         "vscode": "^1.12.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-tcc-compiler",
     "displayName": "TCC Compiler",
     "description": "Extension to simplify use of Tiny C Compiler in VSCode.",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "publisher": "lihram",
     "engines": {
         "vscode": "^1.12.0"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,12 +13,9 @@ export function activate(context: vscode.ExtensionContext) {
   // TCC: Run
   context.subscriptions.push(functions.run());
 
-  // TCC: Run with flags...
-  context.subscriptions.push(functions.runWithFlags());
-
 	 // TCC: Compile
 	context.subscriptions.push(functions.compile());
-	
-	// TCC: Compile with flags...
-	context.subscriptions.push(functions.compileWithFlags());
+
+	// TCC: Set flags
+	context.subscriptions.push(functions.setFlags());
 }

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -1,77 +1,58 @@
 "use strict";
 import * as vscode from "vscode";
+let window = vscode.window;
+let commands = vscode.commands;
+
 import * as path from "path";
+import * as fs from "fs";
 
 let _terminalStack = [];
 let _context = null;
 
-const _execSync = require("child_process").execSync;
-const _execFile = require("child_process").execFile;
-
 /**
- * Compiles and runs the currently open C file.
+ * Runs according to current flags.
+ * Defaults to currently open C file if no flags are given.
  */
 export function run(): vscode.Disposable {
-  return vscode.commands.registerCommand("tcc-compiler.run", () => {
+  return commands.registerCommand("tcc-compiler.run", () => {
     checkTerminal();
-    getLatestTerminal().sendText(tcc(' -run "' + getFileName() + '"'));
+    getLatestTerminal().sendText(tcc(getArgs() + " -run "));
     getLatestTerminal().show();
   });
 }
 
 /**
- * Compiles the current file with user-specified flags and then runs it.
- * It does not save the compiled file.
+ * Runs TCC according to given flags.
+ * Defaults to currently open C file if no tcc.json file is found.
  */
-export function runWithFlags(): vscode.Disposable {
-  return vscode.commands.registerCommand("tcc-compiler.runWithFlags", () => {
-    let flags = " ";
-    vscode.window
-      .showInputBox({ prompt: "Please input flags." })
+export function compile(): vscode.Disposable {
+  return commands.registerCommand("tcc-compiler.compile", () => {
+    checkTerminal();
+    getLatestTerminal().sendText(tcc(getArgs()));
+    getLatestTerminal().show();
+  });
+}
+
+/**
+ * Opens up and edits the current flags.
+ */
+export function setFlags(): vscode.Disposable {
+  return commands.registerCommand("tcc-compiler.setFlags", () => {
+    window
+      .showInputBox({ prompt: "Please input compile arguments." })
       .then((val: string) => {
-        flags += val;
-        checkTerminal();
-        getLatestTerminal().sendText(
-          tcc(flags + ' -run "' + getFileName() + '"')
-        );
-        getLatestTerminal().show();
+        // No input?
+        if (val !== undefined || val === "") {
+          // Write to file.
+          let args = { fileArgs: val };
+          fs.writeFileSync(
+            path.join(getWorkspacePath(), "tcc.json"),
+            JSON.stringify(args)
+          );
+        }
       });
   });
 }
-
-/**
- * Compiles the currently open C file.
- */
-export function compile(): vscode.Disposable {
-  return vscode.commands.registerCommand("tcc-compiler.compile", () => {
-    checkTerminal();
-    _execSync(() => {
-      getLatestTerminal().sendText(tcc(getFileName()));
-      getLatestTerminal().show();
-    });
-  });
-}
-
-/**
- * Compiles the currently open C file with user specified flags.
- */
-export function compileWithFlags(): vscode.Disposable {
-  return vscode.commands.registerCommand(
-    "tcc-compiler.compileWithFlags",
-    () => {
-      let flags = " ";
-      vscode.window
-        .showInputBox({ prompt: "Please input flags." })
-        .then((val: string) => {
-          flags += val;
-          checkTerminal();
-          getLatestTerminal().sendText(tcc(flags + " " + getFileName()));
-					getLatestTerminal().show();
-        });
-    }
-  );
-}
-// Helper functions
 
 /**
  * Sets the context.
@@ -81,11 +62,28 @@ export function setContext(context: vscode.ExtensionContext) {
 }
 
 /**
+ * Gets the arguments from tcc.json
+ */
+function getArgs(): string {
+  let args = " ";
+  try {
+    var argsFile = JSON.parse(
+      fs.readFileSync(path.join(getWorkspacePath(), "tcc.json"), "utf8")
+    );
+    args += argsFile.fileArgs;
+  } catch (error) {
+    args += getFileName();
+  } finally {
+    return args;
+  }
+}
+
+/**
  * Creates a new terminal if none exist.
  */
 function checkTerminal() {
   if (0 === _terminalStack.length) {
-    let terminal = vscode.window.createTerminal(
+    let terminal = window.createTerminal(
       `compiler #${_terminalStack.length + 1}`
     );
     _terminalStack.push(terminal);
@@ -103,7 +101,7 @@ function getLatestTerminal(): vscode.Terminal {
  * Gets the name of the current C file.
  */
 function getFileName(): string {
-  return '"' + vscode.window.activeTextEditor.document.fileName.toString() + '"';
+  return '"' + window.activeTextEditor.document.fileName.toString() + '"';
 }
 
 /**
@@ -111,20 +109,17 @@ function getFileName(): string {
  * @param args Arguments for Tiny C Compiler.
  */
 function tcc(args: string): string {
-  return path.join(_context.extensionPath, "/Compiler/tcc.exe").concat(args);
+  let space = " ";
+  return path
+    .join(_context.extensionPath, "/Compiler/tcc.exe")
+    .concat(space + args);
 }
 
 /**
- * Gets the compilation flags from the user via input box.
+ * If a folder is selected in vscode, then get the current workspace. Otherwise, it is assumed to be the current file folder.
  */
-function getFlags(): Thenable<string> {
-  return vscode.window.showInputBox({ prompt: "Please input flags." }).then(
-    // TODO: Parse flags for validity.
-    (value: string) => {
-      return value;
-    },
-    (reason: any) => {
-      vscode.window.showInformationMessage("Error!" + reason);
-    }
-  );
+function getWorkspacePath(): string {
+  return vscode.workspace.rootPath === undefined
+    ? path.join(getFileName(), "..")
+    : vscode.workspace.rootPath;
 }


### PR DESCRIPTION
Cleaned up the program interface. There are now 3 options:

`TCC: Run`
Runs either from the current configuration, or if that configuration does not exist, runs the currently open c file.

`TCC: Compile`
Compiles either from the current configuration,  or if that configuration does not exist, compiles the currently open c file.

`TCC: Set flags...`
Sets the current configuration for the file. See https://bellard.org/tcc/tcc-doc.html#SEC2 for documentation.